### PR TITLE
fix dataset duration not being close (0.8) to target duration

### DIFF
--- a/example.py
+++ b/example.py
@@ -4,7 +4,7 @@ from tarkibi import build_dataset
 if __name__ == '__main__':
     build_dataset('Elon Musk', 
         reference_audio='reference.wav',
-        target_length=timedelta(minutes=10), 
+        target_duration=timedelta(minutes=10), 
         output_path='dataset', 
-        sample_rate=24000,
+        sample_rate=48000,
     )

--- a/tarkibi/utilities/audio.py
+++ b/tarkibi/utilities/audio.py
@@ -45,8 +45,8 @@ def most_common_audio(audio_directory: str) -> dict:
     return audio_groups
 
 def speaker_recognition(audio_directory: str, reference_audio: str):
-    FAILED_THRESHOLD = 20
-    PASSED_THRESHOLD = 10
+    FAILED_THRESHOLD = 5
+    PASSED_THRESHOLD = 5
 
     speaker_model = nemo_asr.models.EncDecSpeakerLabelModel.from_pretrained("nvidia/speakerverification_en_titanet_large")
     audio_files = get_audio_files(audio_directory)

--- a/tarkibi/utilities/youtube.py
+++ b/tarkibi/utilities/youtube.py
@@ -41,7 +41,10 @@ def youtube_search(query: str):
         'id': video_id,
         'url': f'https://www.youtube.com/watch?v={video_id}'
        })
-      
+    
+    if not results:
+      raise ValueError('No videos found. Try again.')
+
     return results  
 
 def download_video(video_id: str, output_path: str = f'{general.BASE_DIR}/{general.AUDIO_RAW}') -> None:


### PR DESCRIPTION
Parameter `target_duration` is now adhered to, and tarkibi will keep adding audio clips until the dataset is >= 0.8 * target_duration. It was used as rough indicator before. 